### PR TITLE
cli: Add `--max-line-length` to exclude long lines

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -33,6 +33,7 @@ The main feature of **pyhound** is its ``--help`` argument::
     usage: pyhound [-h] [--version] [--endpoint URL] [--repos REPOSITORY_LIST]
                    [--exclude-repos REPOSITORY_LIST] [--path FILE_PATH_PATTERN]
                    [-A NUM] [-B NUM] [-C NUM] [--color [WHEN]] [-i] [-n]
+                   [--line-max-length LINE_MAX_LENGTH]
                    PATTERN
     
     A command-line client for Hound.
@@ -73,6 +74,9 @@ The main feature of **pyhound** is its ``--help`` argument::
                             input files.
       -n, --line-number     Prefix each line of output with the 1-based line
                             number within its input file.
+      --line-max-length LINE_MAX_LENGTH
+                            If given, don't show matching lines if they are longer
+                            than requested.
 
 
 Limitations

--- a/pyhound/cli.py
+++ b/pyhound/cli.py
@@ -68,6 +68,11 @@ def parse_args():
         '-n', '--line-number', action='store_true', dest='show_line_number',
         help="Prefix each line of output with the 1-based line number within its input file.")
 
+    # Misc options: --max-line-length
+    parser.add_argument(
+        '--line-max-length', type=int,
+        help="If given, don't show matching lines if they are longer than requested.")
+
     # Positional argument: the pattern to search.
     parser.add_argument(
         'pattern', metavar="PATTERN", action='store',

--- a/pyhound/hound.py
+++ b/pyhound/hound.py
@@ -78,8 +78,6 @@ def merge_lines(lines):
     When matching and contextual lines overlap, some lines are
     duplicated. This function merges all lines so that they appear
     only once and have the right "line kind".
-
-    FIXME: this is probably inefficient
     """
     # Sort by line number and line kind (match first).
     sorted_lines = sorted(lines, key=lambda l: (l[2], l[3]))

--- a/pyhound/hound.py
+++ b/pyhound/hound.py
@@ -100,7 +100,8 @@ class Client(object):
             color='never',
             ignore_case=False,
             show_line_number=False,
-            ):
+            line_max_length=None,
+    ):
         # Endpoints
         endpoint = endpoint.rstrip('/')
         self.endpoint_list_repos = '%s/api/v1/repos' % endpoint
@@ -127,6 +128,9 @@ class Client(object):
         self.color = color
         self.ignore_case = ignore_case
         self.show_line_number = show_line_number
+
+        # Custom options.
+        self.line_max_length = line_max_length
 
     def get_repo_list(self, repos, exclude_repos):
         """Return a comma-separated list of repositories to look in.
@@ -214,7 +218,10 @@ class Client(object):
                 match['After'],
                 self.before_context,
                 self.after_context,
-                self.context):
+                self.context,
+        ):
+            if self.line_max_length and len(line) > self.line_max_length:
+                continue
             yield (repo, filename, line_number, line_kind, line)
 
     def print_lines(self, lines):

--- a/setup.py
+++ b/setup.py
@@ -30,9 +30,6 @@ setup(
     },
     include_package_data=True,
     long_description=read('README.rst'),
-    install_requires=[
-        'requests<3.0',
-    ],
     tests_require=[l for l in read('requirements_dev.txt').splitlines() if not l.startswith(('-', '#'))],
     test_suite='tests',
     classifiers=[


### PR DESCRIPTION
Sometimes search results include very long lines, for example
concatenated JavaScript or CSS files. I am not sure if we should
exclude them by default (and allow to include them through an option),
or add an option to explicitly exclude them. I chose the latter.

This filtering should probably be implemented in Hound itself (on the
server). But it does not exist yet.